### PR TITLE
download multiple sample raw rds files

### DIFF
--- a/biomage/experiment/download.py
+++ b/biomage/experiment/download.py
@@ -19,6 +19,7 @@ SAMPLES = "samples"
 RAW_FILE = "raw_rds"
 PROCESSED_FILE = "processed_rds"
 CELLSETS = "cellsets"
+SAMPLE_MAPPING = "sample_mapping"
 
 SANDBOX_ID = "default"
 REGION = "eu-west-1"
@@ -185,6 +186,22 @@ def _download_samples(
     click.echo(
         click.style(
             "All samples for the experiment have been downloaded.",
+            fg="green",
+        )
+    )
+
+
+def _download_sample_mapping(
+    experiment_id,
+    input_env,
+    output_path,
+    aws_profile,
+):
+    samples_list = _get_samples(experiment_id, input_env, aws_profile)
+    _create_sample_mapping(samples_list, output_path)
+    click.echo(
+        click.style(
+            "Sample mapping for the experiment has been downloaded.",
             fg="green",
         )
     )
@@ -413,3 +430,7 @@ def download(
             _download_cellsets(
                 experiment_id, input_env, output_path, boto3_session, aws_account_id
             )
+
+        elif file == SAMPLE_MAPPING:
+            print("\n== Download sample mapping file")
+            _download_sample_mapping(experiment_id, input_env, output_path, aws_profile)


### PR DESCRIPTION
# Background

Merge in QC broke `biomage experiment download`, because we now store raw rds files per sample. This PR addresses that, creating a new function to download raw rds files.

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [ ] Run make test
- [ ] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
