### PR TITLE
removed sudo from makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install: clean ## Creates venv, and adds biomage as system command
 	@echo "==> Installing utility and dependencies..."
 	@venv/bin/pip install --upgrade pip
 	@venv/bin/pip install -e .
-	@sudo ln -sf '$(CURDIR)/venv/bin/biomage' $(ENTRY_POINT)
+	@ln -sf '$(CURDIR)/venv/bin/biomage' $(ENTRY_POINT)
 	@echo "    [✓]"
 	@echo
 
@@ -32,7 +32,7 @@ uninstall: clean ## Uninstalls utility and destroys venv
 	@echo "==> Uninstalling utility and dependencies..."
 	@venv/bin/pip uninstall -y biomage-utils
 	@rm -rf venv/
-	@sudo rm -f $(ENTRY_POINT)
+	@rm -f $(ENTRY_POINT)
 	@echo "    [✓]"
 	@echo
 


### PR DESCRIPTION
removed sudo from makefile because in MacOS is not needed and it makes installing the library in docker containers much more cumbersome.