### PR TITLE
Tunnel rds agent filter improvement

### DIFF
--- a/biomage/rds/tunnel.sh
+++ b/biomage/rds/tunnel.sh
@@ -48,7 +48,7 @@ RDSHOST="$(aws rds describe-db-cluster-endpoints \
 	| tr -d '"')"
 
 INSTANCE_DATA=$(aws ec2 describe-instances \
-	--filters "Name=tag:Name,Values=rds-$ENVIRONMENT-ssm-agent" \
+	--filters "Name=tag:Name,Values=rds-$ENVIRONMENT-ssm-agent" "Name=instance-state-name,Values=running" \
 	--output json \
 	--region $REGION \
 	--query "Reservations[*].Instances[*].{InstanceId:InstanceId, AvailabilityZone:Placement.AvailabilityZone}" \

--- a/biomage/rds/tunnel.sh
+++ b/biomage/rds/tunnel.sh
@@ -68,6 +68,6 @@ rm -f "${tmp_socket_prefix}"
 
 ssh-keygen -t rsa -f $tmp_socket_prefix -N ''
 
-AWS_PAGER="" aws ec2-instance-connect send-ssh-public-key --region $REGION --instance-id $INSTANCE_ID --availability-zone $AVAILABILITY_ZONE --instance-os-user ssm-user --ssh-public-key file://$tmp_socket_prefix.pub --profile $AWS_PROFILE
+AWS_PAGER="" aws ec2-instance-connect send-ssh-public-key --region $REGION --instance-id $INSTANCE_ID --availability-zone $AVAILABILITY_ZONE --instance-os-user ec2-user --ssh-public-key file://$tmp_socket_prefix.pub --profile $AWS_PROFILE
 
-ssh -i $tmp_socket_prefix -N -f -M -S $tmp_socket_prefix-ssh.sock -L "$LOCAL_PORT:${RDSHOST}:5432" "ssm-user@${INSTANCE_ID}" -o "IdentitiesOnly yes" -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -o ProxyCommand="aws ssm start-session --target %h --region ${REGION} --profile ${AWS_PROFILE} --document-name AWS-StartSSHSession --parameters portNumber=%p"
+ssh -i $tmp_socket_prefix -N -f -M -S $tmp_socket_prefix-ssh.sock -L "$LOCAL_PORT:${RDSHOST}:5432" "ec2-user@${INSTANCE_ID}" -o "IdentitiesOnly yes" -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -o ProxyCommand="aws ssm start-session --target %h --region ${REGION} --profile ${AWS_PROFILE} --document-name AWS-StartSSHSession --parameters portNumber=%p"


### PR DESCRIPTION
# Background
The rds agent ec2 instance id is found by performing a query for it. This usually is enough, but then fails if the instance picked up is not in running state. This PR adds a filter to the query which checks that instance must be in state running (otherwise it might be an older instance we can't use for this purpose)

#### Link to issue 
N/A

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [ ] Run make test
- [ ] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
